### PR TITLE
DP-1713: Added support for additional REST methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ It is now under _com.edmunds_.
 
 At some point we will plan on deleting the old artifacts from maven-central.
 
+## Additional Details
+This fork is needed in order to add additional features to the repo to be released in a short time
+
+What blocks us from using the upstream version is lack of support for few latest REST endpoints like /jobs/runs/submit and /jobs/runs/get-output in the upstream repo
+
+Command to build jar: mvn clean install -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true verify
+
 ## Build Status
 [![Build Status](https://travis-ci.org/edmunds/databricks-rest-client.svg?branch=master)](https://travis-ci.org/edmunds/databricks-rest-client)
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>2.3.3-SNAPSHOT</version>
+    <version>2.3.3-fs1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Edmunds.com, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.edmunds.rest.databricks.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.util.Date;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ *
+ */
+@Data
+public class RunMetadataDTO implements Serializable {
+
+  @Getter @Setter @JsonProperty("metadata")
+  private RunDTO run;
+
+  @Getter @Setter @JsonProperty("notebook_output")
+  private NotebookOutputDTO notebookOutput;
+
+}

--- a/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
@@ -30,10 +30,14 @@ import lombok.Setter;
 @Data
 public class RunMetadataDTO implements Serializable {
 
-  @Getter @Setter @JsonProperty("metadata")
+  @Getter
+  @Setter
+  @JsonProperty("metadata")
   private RunDTO run;
 
-  @Getter @Setter @JsonProperty("notebook_output")
+  @Getter
+  @Setter
+  @JsonProperty("notebook_output")
   private NotebookOutputDTO notebookOutput;
 
 }

--- a/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/RunMetadataDTO.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 
 
 /**
- *
+ * DTO to hold RunDTO and NotebookOutputDTO values together to get complete run metadata
  */
 @Data
 public class RunMetadataDTO implements Serializable {

--- a/src/main/java/com/edmunds/rest/databricks/service/JobService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobService.java
@@ -204,4 +204,19 @@ public interface JobService {
   void upsertJob(JobSettingsDTO jobSettingsDTO, boolean failOnDuplicateJobNames)
       throws IOException, DatabricksRestException;
 
+  /**
+   * Submit a one-time run. This endpoint doesn’t require a Databricks job to be created
+   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-submit">https://docs.databricks.com/api/latest/jobs.html#runs-submit</a>
+   * @param jobSettings the settings to change the job to
+   * @return Returns the run_id of the triggered run
+   */
+  RunNowDTO runSubmit(JobSettingsDTO jobSettings) throws IOException, DatabricksRestException;
+
+  /**
+   * Retrieve the output of a run
+   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-get-output">https://docs.databricks.com/api/latest/jobs.html#runs-get-output</a>
+   * @param runId The desired run id
+   * @return Returns the data output of the specified run
+   */
+  String getOutput(long runId) throws IOException, DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/JobService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobService.java
@@ -206,17 +206,19 @@ public interface JobService {
 
   /**
    * Submit a one-time run. This endpoint doesn’t require a Databricks job to be created
-   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-submit">https://docs.databricks.com/api/latest/jobs.html#runs-submit</a>
+   *
    * @param jobSettings the settings to change the job to
    * @return Returns the run_id of the triggered run
+   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-submit">https://docs.databricks.com/api/latest/jobs.html#runs-submit</a>
    */
   RunNowDTO runSubmit(JobSettingsDTO jobSettings) throws IOException, DatabricksRestException;
 
   /**
    * Retrieve the output of a run
-   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-get-output">https://docs.databricks.com/api/latest/jobs.html#runs-get-output</a>
+   *
    * @param runId The desired run id
    * @return Returns the data output of the specified run
+   * @see <a href="https://docs.databricks.com/api/latest/jobs.html#runs-get-output">https://docs.databricks.com/api/latest/jobs.html#runs-get-output</a>
    */
   String getOutput(long runId) throws IOException, DatabricksRestException;
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
@@ -16,13 +16,7 @@
 
 package com.edmunds.rest.databricks.service;
 
-import com.edmunds.rest.databricks.DTO.JobDTO;
-import com.edmunds.rest.databricks.DTO.JobSettingsDTO;
-import com.edmunds.rest.databricks.DTO.JobsDTO;
-import com.edmunds.rest.databricks.DTO.RunDTO;
-import com.edmunds.rest.databricks.DTO.RunNowDTO;
-import com.edmunds.rest.databricks.DTO.RunParametersDTO;
-import com.edmunds.rest.databricks.DTO.RunsDTO;
+import com.edmunds.rest.databricks.DTO.*;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.RequestMethod;
 import com.edmunds.rest.databricks.restclient.DatabricksRestClient;
@@ -278,5 +272,26 @@ public class JobServiceImpl extends DatabricksService implements JobService {
         log.info(String.format("Updated job, url: %s", getJobLink(job.getJobId())));
       }
     }
+  }
+
+  @Override
+  public RunNowDTO runSubmit(JobSettingsDTO jobSettings) throws IOException, DatabricksRestException {
+    String marshalled = this.mapper.writeValueAsString(jobSettings);
+    Map<String, Object> data = this.mapper.readValue(marshalled, new
+            TypeReference<Map<String, Object>>() {
+            });
+    byte[] responseBody = client.performQuery(RequestMethod.POST, "/jobs/runs/submit", data);
+    return this.mapper.readValue(responseBody, RunNowDTO.class);
+  }
+
+  @Override
+  public String getOutput(long runId)
+          throws IOException, DatabricksRestException {
+    Map<String, Object> data = new HashMap<>();
+    data.put("run_id", runId);
+
+    byte[] responseBody = client.performQuery(RequestMethod.GET, "/jobs/runs/get-output", data);
+    RunMetadataDTO metadata = this.mapper.readValue(responseBody, RunMetadataDTO.class);
+    return metadata.getNotebookOutput().getResult();
   }
 }

--- a/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/JobServiceImpl.java
@@ -16,7 +16,14 @@
 
 package com.edmunds.rest.databricks.service;
 
-import com.edmunds.rest.databricks.DTO.*;
+import com.edmunds.rest.databricks.DTO.JobDTO;
+import com.edmunds.rest.databricks.DTO.JobSettingsDTO;
+import com.edmunds.rest.databricks.DTO.JobsDTO;
+import com.edmunds.rest.databricks.DTO.RunDTO;
+import com.edmunds.rest.databricks.DTO.RunMetadataDTO;
+import com.edmunds.rest.databricks.DTO.RunNowDTO;
+import com.edmunds.rest.databricks.DTO.RunParametersDTO;
+import com.edmunds.rest.databricks.DTO.RunsDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.RequestMethod;
 import com.edmunds.rest.databricks.restclient.DatabricksRestClient;
@@ -278,15 +285,15 @@ public class JobServiceImpl extends DatabricksService implements JobService {
   public RunNowDTO runSubmit(JobSettingsDTO jobSettings) throws IOException, DatabricksRestException {
     String marshalled = this.mapper.writeValueAsString(jobSettings);
     Map<String, Object> data = this.mapper.readValue(marshalled, new
-            TypeReference<Map<String, Object>>() {
-            });
+        TypeReference<Map<String, Object>>() {
+        });
     byte[] responseBody = client.performQuery(RequestMethod.POST, "/jobs/runs/submit", data);
     return this.mapper.readValue(responseBody, RunNowDTO.class);
   }
 
   @Override
   public String getOutput(long runId)
-          throws IOException, DatabricksRestException {
+      throws IOException, DatabricksRestException {
     Map<String, Object> data = new HashMap<>();
     data.put("run_id", runId);
 

--- a/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
@@ -16,28 +16,29 @@
 
 package com.edmunds.rest.databricks.service;
 
-import com.edmunds.rest.databricks.DTO.*;
+import com.edmunds.rest.databricks.DTO.ExportFormatDTO;
+import com.edmunds.rest.databricks.DTO.JobDTO;
+import com.edmunds.rest.databricks.DTO.JobSettingsDTO;
+import com.edmunds.rest.databricks.DTO.LanguageDTO;
+import com.edmunds.rest.databricks.DTO.NotebookTaskDTO;
+import com.edmunds.rest.databricks.DTO.RunDTO;
+import com.edmunds.rest.databricks.DTO.RunNowDTO;
+import com.edmunds.rest.databricks.DTO.RunsDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.DatabricksServiceFactory;
-import com.edmunds.rest.databricks.JobRunner;
 import com.edmunds.rest.databricks.TestUtil;
 import com.edmunds.rest.databricks.fixtures.DatabricksFixtures;
 import com.edmunds.rest.databricks.request.ImportWorkspaceRequest;
 import com.edmunds.rest.databricks.request.ImportWorkspaceRequest.ImportWorkspaceRequestBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-
-import static com.edmunds.rest.databricks.fixtures.DatabricksFixtures.*;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class JobTest {
   private static final String JOB_NAME = "JobRunnerTest_test_job";
@@ -60,11 +61,11 @@ public class JobTest {
     InputStream stream = this.getClass().getClassLoader().getResourceAsStream("test_notebook.scala");
     byte[] content = IOUtils.toByteArray(stream);
     ImportWorkspaceRequest request = new ImportWorkspaceRequestBuilder(NOTEBOOK_PATH)
-            .withContent(content)
-            .withFormat(ExportFormatDTO.SOURCE)
-            .withLanguage(LanguageDTO.SCALA)
-            .withOverwrite(true)
-            .build();
+        .withContent(content)
+        .withFormat(ExportFormatDTO.SOURCE)
+        .withLanguage(LanguageDTO.SCALA)
+        .withOverwrite(true)
+        .build();
     workspaceService.importWorkspace(request);
 
     NotebookTaskDTO notebook_task = new NotebookTaskDTO();
@@ -95,7 +96,7 @@ public class JobTest {
 
   @Test
   public void main_runExists()
-          throws InterruptedException, DatabricksRestException, IOException, ParseException {
+      throws InterruptedException, DatabricksRestException, IOException, ParseException {
     RunsDTO runsDTO = service.listRuns(runDTO.getJobId(), null, null, null);
     assertEquals(runsDTO.getRuns().length, 1);
   }

--- a/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2018 Edmunds.com, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.edmunds.rest.databricks.service;
+
+import com.edmunds.rest.databricks.DTO.*;
+import com.edmunds.rest.databricks.DatabricksRestException;
+import com.edmunds.rest.databricks.DatabricksServiceFactory;
+import com.edmunds.rest.databricks.JobRunner;
+import com.edmunds.rest.databricks.TestUtil;
+import com.edmunds.rest.databricks.fixtures.DatabricksFixtures;
+import com.edmunds.rest.databricks.request.ImportWorkspaceRequest;
+import com.edmunds.rest.databricks.request.ImportWorkspaceRequest.ImportWorkspaceRequestBuilder;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.IOUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static com.edmunds.rest.databricks.fixtures.DatabricksFixtures.*;
+import static org.testng.Assert.assertEquals;
+
+//TODO cleanup
+public class JobTest {
+  private static final String JOB_NAME = "JobRunnerTest_test_job";
+  private static final String NOTEBOOK_PATH = "/tmp/testing/test_notebook.scala";
+  private JobService service;
+  private WorkspaceService workspaceService;
+  private RunDTO runDTO ;
+  private RunNowDTO runNowDTO ;
+  private String[] argsWithJobId;
+  private String[] argsWithJobName;
+  private String[] argsWithInvalidJobName;
+
+  @BeforeClass(enabled = true)
+  public void setUpOnce() throws IOException, DatabricksRestException {
+    DatabricksServiceFactory factory = DatabricksFixtures.getDatabricksServiceFactory();
+    service = factory.getJobService();
+    workspaceService = factory.getWorkspaceService();
+
+    //TODO repeated code from job service, also keep DRY with notebook path
+    workspaceService.mkdirs("/tmp/testing/");
+    InputStream stream = this.getClass().getClassLoader().getResourceAsStream("test_notebook.scala");
+    byte[] content = IOUtils.toByteArray(stream);
+    ImportWorkspaceRequest request = new ImportWorkspaceRequestBuilder(NOTEBOOK_PATH)
+        .withContent(content)
+        .withFormat(ExportFormatDTO.SOURCE)
+        .withLanguage(LanguageDTO.SCALA)
+        .withOverwrite(true)
+        .build();
+    workspaceService.importWorkspace(request);
+
+    NotebookTaskDTO notebook_task = new NotebookTaskDTO();
+    notebook_task.setNotebookPath(NOTEBOOK_PATH);
+    String defaultClusterId = TestUtil.getDefaultClusterId(factory.getClusterService());
+    JobSettingsDTO jobSettingsDTO = new JobSettingsDTO();
+    jobSettingsDTO.setName(JOB_NAME);
+    jobSettingsDTO.setExistingClusterId(defaultClusterId);
+    jobSettingsDTO.setNotebookTask(notebook_task);
+
+    // there's possibility test TearDownFailure. it cause test job not-deleted.
+    List<JobDTO> jobList = service.getJobsByName(JOB_NAME);
+    for (JobDTO jobDTO : jobList) {
+      service.deleteJob(jobDTO.getJobId());
+    }
+
+    runNowDTO = service.runSubmit(jobSettingsDTO);
+    runDTO = service.getRun(runNowDTO.getRunId());
+
+    argsWithJobId = new String[] {
+        "-u " + USERNAME,
+        "-p " + PASSWORD,
+        "-h " + HOSTNAME,
+        "-j " + runDTO.getJobId()
+    };
+
+    argsWithJobName = new String[] {
+        "-u " + USERNAME,
+        "-p " + PASSWORD,
+        "-h " + HOSTNAME,
+        "-n " + JOB_NAME
+    };
+
+    argsWithInvalidJobName =
+        new String[] {
+            "-u " + USERNAME,
+            "-p " + PASSWORD,
+            "-h " + HOSTNAME,
+            "-n " + "Fake Job Name"
+        };
+
+  }
+
+
+  @AfterClass(alwaysRun = true)
+  public void tearDownOnce() throws IOException, DatabricksRestException {
+    service.deleteJob(runDTO.getJobId());
+
+    workspaceService.delete(NOTEBOOK_PATH, false);
+  }
+
+  @Test
+  public void main_whenCalledWithArguments_startsRunOfJob()
+      throws InterruptedException, DatabricksRestException, IOException, ParseException {
+    int expected = getNumberOfRuns(runDTO.getJobId()) + 1;
+
+    JobRunner.main(argsWithJobId);
+
+    int numberOfRuns = getNumberOfRuns(runDTO.getJobId());
+    assertEquals(numberOfRuns, expected);
+  }
+
+  @Test
+  public void main_whenCalledWithJobName_startsRunOfJob()
+      throws InterruptedException, DatabricksRestException, ParseException, IOException {
+    int expected = getNumberOfRuns(runDTO.getJobId()) + 1;
+
+    JobRunner.main(argsWithJobName);
+
+    int numberOfRuns = getNumberOfRuns(runDTO.getJobId());
+    assertEquals(numberOfRuns, expected);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void main_whenCalledWithInvalidJobName_throwsIllegalArgumentException()
+      throws InterruptedException, DatabricksRestException, ParseException, IOException {
+    JobRunner.main(argsWithInvalidJobName);
+  }
+
+  @Test
+  public void main_whenCalled_runsToCompletionWithSuccess()
+      throws InterruptedException, DatabricksRestException, ParseException, IOException {
+    JobRunner.main(argsWithJobId);
+
+    assertEquals(runDTO.getState().getLifeCycleState(), RunLifeCycleStateDTO.TERMINATED);
+    assertEquals(runDTO.getState().getResultState(), RunResultStateDTO.SUCCESS);
+  }
+
+  private RunDTO getMostRecentRun(Long jobId) throws IOException, DatabricksRestException {
+    return service.listRuns(jobId, null, null, null).getRuns()[0];
+  }
+
+  private int getNumberOfRuns(long jobId) throws IOException, DatabricksRestException {
+    RunsDTO runsDTO = service.listRuns(runDTO.getJobId(), null, null, null);
+    return runsDTO.getRuns() != null ? runsDTO.getRuns().length : 0;
+  }
+}

--- a/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
@@ -39,7 +39,6 @@ import static com.edmunds.rest.databricks.fixtures.DatabricksFixtures.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-//TODO cleanup
 public class JobTest {
   private static final String JOB_NAME = "JobRunnerTest_test_job";
   private static final String NOTEBOOK_PATH = "/tmp/testing/test_notebook.scala";
@@ -57,7 +56,6 @@ public class JobTest {
     service = factory.getJobService();
     workspaceService = factory.getWorkspaceService();
 
-    //TODO repeated code from job service, also keep DRY with notebook path
     workspaceService.mkdirs("/tmp/testing/");
     InputStream stream = this.getClass().getClassLoader().getResourceAsStream("test_notebook.scala");
     byte[] content = IOUtils.toByteArray(stream);
@@ -103,39 +101,3 @@ public class JobTest {
   }
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/JobTest.java
@@ -32,10 +32,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.edmunds.rest.databricks.fixtures.DatabricksFixtures.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 //TODO cleanup
 public class JobTest {
@@ -43,8 +45,8 @@ public class JobTest {
   private static final String NOTEBOOK_PATH = "/tmp/testing/test_notebook.scala";
   private JobService service;
   private WorkspaceService workspaceService;
-  private RunDTO runDTO ;
-  private RunNowDTO runNowDTO ;
+  private RunDTO runDTO;
+  private RunNowDTO runNowDTO;
   private String[] argsWithJobId;
   private String[] argsWithJobName;
   private String[] argsWithInvalidJobName;
@@ -60,11 +62,11 @@ public class JobTest {
     InputStream stream = this.getClass().getClassLoader().getResourceAsStream("test_notebook.scala");
     byte[] content = IOUtils.toByteArray(stream);
     ImportWorkspaceRequest request = new ImportWorkspaceRequestBuilder(NOTEBOOK_PATH)
-        .withContent(content)
-        .withFormat(ExportFormatDTO.SOURCE)
-        .withLanguage(LanguageDTO.SCALA)
-        .withOverwrite(true)
-        .build();
+            .withContent(content)
+            .withFormat(ExportFormatDTO.SOURCE)
+            .withLanguage(LanguageDTO.SCALA)
+            .withOverwrite(true)
+            .build();
     workspaceService.importWorkspace(request);
 
     NotebookTaskDTO notebook_task = new NotebookTaskDTO();
@@ -84,30 +86,7 @@ public class JobTest {
     runNowDTO = service.runSubmit(jobSettingsDTO);
     runDTO = service.getRun(runNowDTO.getRunId());
 
-    argsWithJobId = new String[] {
-        "-u " + USERNAME,
-        "-p " + PASSWORD,
-        "-h " + HOSTNAME,
-        "-j " + runDTO.getJobId()
-    };
-
-    argsWithJobName = new String[] {
-        "-u " + USERNAME,
-        "-p " + PASSWORD,
-        "-h " + HOSTNAME,
-        "-n " + JOB_NAME
-    };
-
-    argsWithInvalidJobName =
-        new String[] {
-            "-u " + USERNAME,
-            "-p " + PASSWORD,
-            "-h " + HOSTNAME,
-            "-n " + "Fake Job Name"
-        };
-
   }
-
 
   @AfterClass(alwaysRun = true)
   public void tearDownOnce() throws IOException, DatabricksRestException {
@@ -117,48 +96,46 @@ public class JobTest {
   }
 
   @Test
-  public void main_whenCalledWithArguments_startsRunOfJob()
-      throws InterruptedException, DatabricksRestException, IOException, ParseException {
-    int expected = getNumberOfRuns(runDTO.getJobId()) + 1;
-
-    JobRunner.main(argsWithJobId);
-
-    int numberOfRuns = getNumberOfRuns(runDTO.getJobId());
-    assertEquals(numberOfRuns, expected);
-  }
-
-  @Test
-  public void main_whenCalledWithJobName_startsRunOfJob()
-      throws InterruptedException, DatabricksRestException, ParseException, IOException {
-    int expected = getNumberOfRuns(runDTO.getJobId()) + 1;
-
-    JobRunner.main(argsWithJobName);
-
-    int numberOfRuns = getNumberOfRuns(runDTO.getJobId());
-    assertEquals(numberOfRuns, expected);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void main_whenCalledWithInvalidJobName_throwsIllegalArgumentException()
-      throws InterruptedException, DatabricksRestException, ParseException, IOException {
-    JobRunner.main(argsWithInvalidJobName);
-  }
-
-  @Test
-  public void main_whenCalled_runsToCompletionWithSuccess()
-      throws InterruptedException, DatabricksRestException, ParseException, IOException {
-    JobRunner.main(argsWithJobId);
-
-    assertEquals(runDTO.getState().getLifeCycleState(), RunLifeCycleStateDTO.TERMINATED);
-    assertEquals(runDTO.getState().getResultState(), RunResultStateDTO.SUCCESS);
-  }
-
-  private RunDTO getMostRecentRun(Long jobId) throws IOException, DatabricksRestException {
-    return service.listRuns(jobId, null, null, null).getRuns()[0];
-  }
-
-  private int getNumberOfRuns(long jobId) throws IOException, DatabricksRestException {
+  public void main_runExists()
+          throws InterruptedException, DatabricksRestException, IOException, ParseException {
     RunsDTO runsDTO = service.listRuns(runDTO.getJobId(), null, null, null);
-    return runsDTO.getRuns() != null ? runsDTO.getRuns().length : 0;
+    assertEquals(runsDTO.getRuns().length, 1);
   }
+
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
1.Currently foursquare/databricks-rest-client fork has no option to run a job without creating it first. Need to create the equivalent of '2.0/jobs/runs/submit' in it.

2. Similarly need to create equivalent of '2.0/jobs/runs/get-output' to get the output location of a run